### PR TITLE
Non version increasing changes

### DIFF
--- a/RCM-DX-Specification_EN.md
+++ b/RCM-DX-Specification_EN.md
@@ -129,12 +129,12 @@ Groups are described in this specification as follows:
 
 | Name | Parent object | Optional |
 |--|--|--|
-| `SESSION` | `RCMDX` | no |
+| `GROUP` | `RCMDX` | no |
 
 **Name**  
 The name of the group.
 
-> Group names whose ending is "_NAME" are wildcard names and are replaced as described in the corresponding paragraph. Example: *SESSION_NAME*
+> Group names whose ending is "_NAME" are wildcard names and are replaced as described in the corresponding paragraph. Example: *GROUP_NAME*
 
 **Parent object**  
 A group can be a subgroup of a group, here the name of this group is mentioned. If the name is written in quotation marks, it can be freely chosen by the creator of the file. Without quotation marks, the name of the group is meant.
@@ -446,7 +446,9 @@ Separate and more detailed specifications have been written for individual struc
 
 The individual groups are specified in more detail below in the subcategories.
 
-### Root Group
+### Root
+
+Root is of type 'Group' in HDF5.
 
 The root group contains all other subgroups. This group defines the RCM-DX and bears its name and thus refers to this specification.
 
@@ -466,7 +468,9 @@ The following attributes are assigned to the group `RCMDX`:
 | Minor | 16 bit integer | `RCMDX` | no | Minor Version of the RCM-DX specification that corresponds to the structure of the created file |
 | Feature | 16 bit integer | `RCMDX` | no | Feature Version of the RCM-DX specification that corresponds to the structure of the created file |
 
-### File Group
+### File
+
+File is of type 'Group' in HDF5.
 
 The file group contains file specific information, i.e. information specific for the given data set in its current processing state.
 
@@ -485,7 +489,9 @@ The file group contains the following attribute:
 | Element | string | no | Equals to "File". Identifies this node.|
 | StructureVersion | string | no | Version identifier of the platform structure. All underlying systems, datasources and channels can be identified based on this version |
 
-### Data Processing Group
+### Data Processing
+
+Data Processing is of type 'Group' in HDF5.
 
 The data source group `DATAPROCESSING` contains information about the data in this file, and the processing.
 
@@ -493,7 +499,9 @@ The data source group `DATAPROCESSING` contains information about the data in th
 |--|--|--|
 | `DATAPROCESSING` | `FILE` | yes |
 
-### Processing log Group
+### Processing log
+
+Processing log is of type 'Group' in HDF5.
 
 The data source group `PROCESSINGLOG` contains information on data processing. This information is written by systems that make changes to the data. These changes, for example, can be a conversion from millimeters to meters.
 
@@ -501,7 +509,7 @@ The data source group `PROCESSINGLOG` contains information on data processing. T
 |--|--|--|
 | `PROCESSINGLOG` | `DATAPROCESSING` | yes |
 
-#### Processing log Group datasets
+#### Processing log datasets
 
 The group `PROCESSINGLOG` contains one dataset:
 
@@ -542,7 +550,9 @@ Optional user-ID of the initiator of this processing step.
 **message**  
 Optional message of the user.
 
-### Clearance Group
+### Clearance
+
+Clearance is of type 'Group' in HDF5.
 
 This group is used by SBB to record information about the data release of all parties who have processed this data. The information is stored in the form of key-value pairs in a data set.
 
@@ -580,7 +590,9 @@ User-ID of the initiator of this clearance.
 Optional message of the user.
 
 
-### Platform Group
+### Platform
+
+Platform is of type 'Group' in HDF5.
 
 A platform group contains information about a measuring vehicle that collects the data.  
 The naming of the group is defined according to which platform produced the data. An overview of all names and the corresponding platform is specified in the chapter [Platforms at the SBB](#platforms-at-the-sbb).
@@ -611,7 +623,9 @@ Below is a list of the defined unique names of the platforms and their names.
 | DFZ02 | SPZ | - |
 | DFZ04 | OBM-N | - |
 
-### Session Group  
+### Session 
+
+Session is of type 'Group' in HDF5.  
 
 The session group contains data that was collected during the same period. A session group contains data from different sources. A RCM-DX file contains exactly one session group.
 
@@ -651,7 +665,9 @@ For a certain period of time, only one session can exist in a file, this must be
 | EndTime | Timestamp | *SESSION_NAME* | yes | Timestamp in nanoseconds as end time of the session. If the session has not yet been closed, this attribute is missing |
 
 
-### Session configuration Group
+### Session configuration
+
+Session configuration is of type 'Group' in HDF5.
 
 Configurations can be stored in the datasets of this group. The datasets are designed so that global and network specific configurations can be stored. The configuration can change and have not to be the same in each session.
 
@@ -659,7 +675,9 @@ Configurations can be stored in the datasets of this group. The datasets are des
 |--|--|--|
 | `CONFIGURATION` | *SESSION_NAME* | no |
 
-### Topology Group
+### Topology
+
+Topology is of type 'Group' in HDF5.
 
 A topology group contains all information on the route network of the respective railway company.  
 This chapter has been optimised for SBB and may differ between railway companies. SBB's data processing chain provides for this structure, which is why it is described here.
@@ -691,7 +709,9 @@ The DfA (Database of fixed assets) is a SBB construct and reflects the SBB route
 List of attributes defined by SBB Diamond. All attributes start with “diamond-“ and have a String value.
 
 
-### Track Group
+### Track
+
+Track is of type 'Group' in HDF5.
 
 This group contains information on the tracks of the railway network. The information is stored in separate datasets.
 
@@ -765,7 +785,9 @@ The number in the *tracktype* data set defines the type of track that belongs to
 | 1 | Track |
 | 2 | Switch |
 
-### Line Group
+### Line
+
+Line is of type 'Group' in HDF5.
 
 This group contains information about a line in the route network. The information is stored in separate datasets.
 
@@ -803,7 +825,9 @@ Start kilometre of the line, expressed in kilometres.
 **tokilometer**  
 Final kilometer of the line, in kilometers.
 
-### Switch Track Group
+### Switch Track
+
+Switch track is of type 'Group' in HDF5.
 
 This group contains information about switches in the route network. The information is stored in separate datasets.
 
@@ -865,7 +889,9 @@ Contains the ID's of the switches as a reference.
 **soft tongue**   
  -->
 
-### Track Object Group
+### Track Object
+
+Track object is of type 'Group' in HDF5.
 
 This group contains information about objects in the route network, for example a balise. The information is stored in separate datasets.
 
@@ -899,7 +925,9 @@ End position of the object in meters.
 **Extrainfo**  
 Additional information about the object, for example, the ID of a balise.
 
-### Track Point Group
+### Track Point
+
+Track point is of type 'Group' in HDF5.
 
 This group contains information about defined points on the route network. The information is stored in separate datasets.
 
@@ -953,7 +981,9 @@ The inclination at this point, expressed in millimetres.
 **steigung**  
 Gradient at this point, expressed in parts per thousand.
 
-### Property Group
+### Property
+
+Property is of type 'Group' in HDF5.
 
 This group contains information about properties of the topology itself. The information is stored in separate datasets.
 
@@ -991,7 +1021,9 @@ Description of the characteristic in Italian language.
 **description.en**  
 Description of the feature in English language.
 
-### Setting Group
+### Setting
+
+Setting is of type 'Group' in HDF5.
 
 Within this group there are further groups whose names identify the type of setting.  
 In the following *SETTING_NAME* is used as placeholder of the actual name of a setting.
@@ -1020,7 +1052,9 @@ The following attributes are contained in this group:
 |---|---|---|---|-----|
 | DataType | string | `setting` | no | Defines the datatype of the configuration within the data set `setting`. Data type specified as MIME^3^ type, for example `Content-Type: <text/strings>` |
 
-### Sections Group
+### Sections
+
+Section is of type 'Group' in HDF5.
 
 The group `SECTIONS`, contains information about a session.
 
@@ -1098,7 +1132,9 @@ Start covered distance of the track in the section.
 **trackEndCoveredDistance**  
 End covered distance of the track in the section.
 
-### Measuring System Group
+### Measuring System
+
+Measurement system is of type 'Group' in HDF5.
 
 Each measuring system has its own data sources, which have their own names, as well as their own channels, which in turn have their own names. Common features are described in this specification, everything else is defined in a separate specification. Since this part differs greatly among railway companies and with measuring equipment, a rigid specification has been dispensed with, but a certain framework is still given.
 
@@ -1118,7 +1154,9 @@ The following attributes are contained in the group of the measuring system:
 |---|---|-----|---|-----|
 | Element | string | *MEASURINGSYSTEM_NAME* | no | Indicates the type of the group, this is fixed `System` |
 
-### Datasource Group
+### Datasource
+
+Datasource is of type 'Group' in HDF5.
 
 A data source group can contain several channels and thus several data sources. This group combines these channels. The naming can be freely selected, but must be unique.
 
@@ -1149,7 +1187,9 @@ Each data source group contains a data set called `timestamp`. It contains all t
 
 A more detailed description can be found in the chapter [\ref{timestamp} Timestamp Array](#timestamp)!
 
-### Channel Group
+### Channel
+
+Channel is of type 'Group' in HDF5.
 
 A channel group contains metadata for the actual measurement data and thus for the various channels. The naming can be freely selected, but must be unique within the data source group.
 
@@ -1281,7 +1321,9 @@ The physical unit of the measurement data, such as "millimeter". If no physical 
 
 The data set and the possible data that can be stored are described in more detail in the chapter [\ref{hdf5-datasets} Dataset](#hdf5-datasets).
 
-### Measurement mode group
+### Measurement mode
+
+Measurement mode is of type 'Group' in HDF5.
 
 The following group contains important information about the measurement mode of the system.
 
@@ -1310,7 +1352,9 @@ There are three different measurement modes, which are explained individually be
 | TEST | Test data recorded during a diagnostic run with the aim of checking and testing the measuring equipment. |
 | SIMULATION | Simulated values that the measuring systems produce themselves and are no longer used. |
 
-### Logging Group
+### Logging
+
+Logging is of type 'Group' in HDF5.
 
 The logging group contains information about the status of the measuring systems. The data is divided into two subgroups, `AVAILABILITY` and `MESSAGES`. These are described in separate chapters.
 
@@ -1320,7 +1364,9 @@ The logging group contains information about the status of the measuring systems
 
 ![Logging group overview](images/generated/rcmdx_logging_group.png){width=320px}
 
-#### Availability Group
+#### Availability
+
+Availability is of type 'Group' in HDF5.
 
 In this group, failures and interruptions of measurement systems are recorded in a defined structure, each as its own data set.
 
@@ -1373,7 +1419,9 @@ Defines the severity of the failure or interruption of a measurement system. The
 | FAILURE | The measuring system or sensor has failed and has not recorded any measured values during the session. |
 | WARNING | The measuring system or the sensor may have had a failure and the measured values may not be correct. |
 
-#### Consistency group
+#### Consistency
+
+Consistency is of type 'Group' in HDF5.
 
 The message about the consistency of the data is triggered by a system that checks all data according to certain criteria. For example, this could be a check for black images in a video. If all frames in the video are black, something is wrong and the video is unusable. 
 
@@ -1414,7 +1462,9 @@ The consistency type can have the following values:
 **consistencyinfo**  
 Contains additional information about this consistency (E.g. which rule decided the consistency type).
 
-#### Message Group
+#### Message
+
+Message is of type 'Group' in HDF5.
 
 This group contains messages, generated from a measurement system or a person, structured in data set.
 
@@ -1459,7 +1509,9 @@ Defines the importance of a message. Following values are possible:
 | WARNING | The message indicates a warning. |
 | ERROR | The message indicates an error. |
 
-### Position group
+### Position
+
+Position is of type 'Group' in HDF5.
 
 This group contains general information on the position. It is like a measuring system (see [\ref{measuring-system-group} Measuring System group](#measuring-system-group)) with following differences:
 
@@ -1542,7 +1594,9 @@ The following values are allowed:
 | INCREASING | Increasing track kilometrage on the track |
 | DECREASING | Decreasing track kilometrage on the track |
 
-### EVENTS Group  
+### EVENTS
+
+Events is of type 'Group' in HDF5.
 
 The EVENTS group is used to store events that occurred during the recording of data. Events are bound to a channel, system or session and have a link to it.
 Systems can, for example, trigger an EVENT when a limit value is exceeded. Events are always time-bound which means an EVENT contains the exact time of occurrence and the duration of the EVENT. The duration can also be zero, so the EVENT occurred exactly at the specified time.  
@@ -1723,7 +1777,9 @@ The XML schema can be found in chapter [\ref{events-generic} EventsGeneric](#eve
 | Username | Name of the user who recorded the message | Corrupt |
 | ID | Unique ID of this message | Corrupt |
 
-### Measurement system configuration Group
+### Measurement system configuration
+
+Measurement system configuration is of type 'Group' in HDF5.
 
 The structure of this group is the __same__ as for the configuration group below the group *SESSION_NAME*: [\ref{session-configuration-group} Session configuration group](#platform-configuration-group), but __the parent group__ is `*MEASURINGSYSTEM_NAME*`: [\ref{measuring-system-group} Measuring system group](#measuring-system-group). The measuring system configuration group also does not contain the Topology.
 

--- a/RCM-DX-Specification_EN.md
+++ b/RCM-DX-Specification_EN.md
@@ -594,7 +594,7 @@ Optional message of the user.
 
 Platform is of type 'Group' in HDF5.
 
-A platform group contains information about a measuring vehicle that collects the data.  
+A platform group contains information about a measuring vehicle, mobile or handheld device that collects the data.  
 The naming of the group is defined according to which platform produced the data. An overview of all names and the corresponding platform is specified in the chapter [Platforms at the SBB](#platforms-at-the-sbb).
 
 ![Platform group overview](images/generated/rcmdx_platform_group.png)

--- a/RCM-DX-Specification_EN.md
+++ b/RCM-DX-Specification_EN.md
@@ -47,6 +47,7 @@ The RCM-DX specification is open source and freely accessible and usable by all 
 | 2.0.0 | 0.31 | 11.03.2021 | Aron Serafini (SCS) | Adjust specification to implementation |
 | 2.0.0 | 0.32 | 31.08.2021 | Aron Serafini (SCS) | Fix mistake: Topology is a child of CONFIGURATION, not Session. |
 | 2.0.1 | 1.0 | 06.04.2022 | Aron Serafini (SCS) | Add attribute MeasurementDirectionDependent to Channel. Use a release version for this document. |
+| 2.0.1 | 1.01 | 05.06.2023 | Mathias Vanden Auweele (Infrabel) | Removed 'group' in all titles and replaced with a reference to HDF5 group. Fix definition of UNRELEASED under the CLEARANCE group. Clarify the definition of "Platform". Changed the limitative platform list into an example platform list. |
 
 ## Introduction  
 

--- a/RCM-DX-Specification_EN.md
+++ b/RCM-DX-Specification_EN.md
@@ -1193,7 +1193,7 @@ A more detailed description can be found in the chapter [\ref{timestamp} Timesta
 
 Channel is of type 'Group' in HDF5.
 
-A channel group contains metadata for the actual measurement data and thus for the various channels. The naming can be freely selected, but must be unique within the data source group.
+A channel group contains metadata for the actual measurement data available in the channel. The naming can be freely selected, but must be unique within the data source group.
 
 | Name | Parent object | Optional |
 |--|--|--|

--- a/RCM-DX-Specification_EN.md
+++ b/RCM-DX-Specification_EN.md
@@ -595,7 +595,7 @@ Optional message of the user.
 Platform is of type 'Group' in HDF5.
 
 A platform group contains information about a measuring vehicle, mobile or handheld device that collects the data.  
-The naming of the group is defined according to which platform produced the data. An overview of all names and the corresponding platform is specified in the chapter [Platforms at the SBB](#platforms-at-the-sbb).
+The naming of the group is defined according to which platform produced the data. An example list of platforms and associated data is provided in the [Platforms example list](#platforms-example-list) chapter.
 
 ![Platform group overview](images/generated/rcmdx_platform_group.png)
 
@@ -612,16 +612,18 @@ The platform group contains the following attributes:
 | Element | string | no | Equals to "Platform". Identifies this node.|
 | VehicleNumber | string | no | Unique number of the vehicle |
 
-#### Platforms at the SBB
+#### Platforms example list
 
-Below is a list of the defined unique names of the platforms and their names.
+Below is a list of the defined unique names of the platforms, their abbreviation and the associated vehicle number.
 
 | Platform Name | Abbreviation | Vehicle Number |
 |---|---|-----|
 | DFZ00 | DFZ | - |
 | DFZ01 | gDFZ | - |
-| DFZ02 | SPZ | - |
-| DFZ04 | OBM-N | - |
+| EM130 | EM130 | 99 88 9162001-0 |
+| EM201 | EM201 | 99 88 9163201-5 |
+
+The Vehicle number is the European Vehicle Number (EVN).
 
 ### Session 
 

--- a/RCM-DX-Specification_EN.md
+++ b/RCM-DX-Specification_EN.md
@@ -578,7 +578,7 @@ This record contains the enum value of the clearance. The following values are p
 |----|------|
 | RELEASED | This file has been released |
 | PENDING | The clearance has not been set yet |
-| UNRELEASED | This file has not yet been released |
+| UNRELEASED | This file won't be released |
 
 **timestamp**  
 Contains the time of the acquisition of the entry.


### PR DESCRIPTION
Following changes were made after discussion between SBB & Infrabel:
- Removed 'group' in all titles and replaced with a reference to HDF5 group
- Fix definition of UNRELEASED under the CLEARANCE group
- Clarify the definition of "Platform"
- Changed the limitative platform list into an example platform list

These changes are only improving the existing specification and should not require an increase in version. 