### PR TITLE
chore: update pandoc to 3.9 and enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Update Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore: "
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci: "
+    open-pull-requests-limit: 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/extra:3.7
+FROM pandoc/extra:3.9
 
 RUN apk add --no-cache \
   envsubst \

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ pdf: images ## generate PDF specification
 	mkdir -p generated-specs/pdf
 	envsubst < metadata.md > _metadata.md
 ifeq ($(IS_DRAFT),true)
-	pandoc --from markdown --template eisvogel --listings --include-in-header templates/is_draft.latex --metadata-file=_metadata.md RCM-DX-Specification_EN.md -o generated-specs/pdf/RCM-DX-Specification_EN.pdf --pdf-engine tectonic
+	pandoc --from markdown --template eisvogel --syntax-highlighting=idiomatic --include-in-header templates/is_draft.latex --metadata-file=_metadata.md RCM-DX-Specification_EN.md -o generated-specs/pdf/RCM-DX-Specification_EN.pdf --pdf-engine tectonic
 else
-	pandoc --from markdown --template eisvogel --listings --metadata-file=_metadata.md RCM-DX-Specification_EN.md -o generated-specs/pdf/RCM-DX-Specification_EN.pdf --pdf-engine tectonic
+	pandoc --from markdown --template eisvogel --syntax-highlighting=idiomatic --metadata-file=_metadata.md RCM-DX-Specification_EN.md -o generated-specs/pdf/RCM-DX-Specification_EN.pdf --pdf-engine tectonic
 endif
 	rm _metadata.md


### PR DESCRIPTION
Adding dependabot should ensure that pandoc and GitHub build actions will automatically be updated in the future