### PR TITLE
ci: update GitHub actions

### DIFF
--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           load: true
           tags: rcm-dx-specification:latest
@@ -60,7 +60,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
 
       - name: Upload PDF
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: RCM-DX-Specification_EN
           path: generated-specs/pdf/RCM-DX-Specification_EN.pdf

--- a/.github/workflows/make-pdf.yaml
+++ b/.github/workflows/make-pdf.yaml
@@ -65,3 +65,4 @@ jobs:
           name: RCM-DX-Specification_EN
           path: generated-specs/pdf/RCM-DX-Specification_EN.pdf
           if-no-files-found: error
+          archive: false


### PR DESCRIPTION
Update GitHub actions to newest releases and switch to unzipped uploads for PDF upload.